### PR TITLE
Add interactive cube example

### DIFF
--- a/interactive_cube.html
+++ b/interactive_cube.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Interactive Cube</title>
+<style>
+  body {
+    margin: 0;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: #111;
+    color: white;
+    font-family: sans-serif;
+    overflow: hidden;
+  }
+  .scene {
+    width: 200px;
+    height: 200px;
+    perspective: 600px;
+  }
+  .cube {
+    width: 100%;
+    height: 100%;
+    transform-style: preserve-3d;
+    transition: transform 0.6s cubic-bezier(0.17,0.67,0.35,1.3);
+  }
+  .face {
+    position: absolute;
+    width: 200px;
+    height: 200px;
+    line-height: 200px;
+    text-align: center;
+    font-size: 24px;
+    color: #fff;
+    background: rgba(0,0,0,0.5);
+    border: 2px solid #fff;
+  }
+  .front  { transform: translateZ(100px);  background: #f44336; }
+  .back   { transform: rotateY(180deg) translateZ(100px); background: #2196f3; }
+  .right  { transform: rotateY(90deg)  translateZ(100px); background: #4caf50; }
+  .left   { transform: rotateY(-90deg) translateZ(100px); background: #ffeb3b; color:#000; }
+  .top    { transform: rotateX(90deg)  translateZ(100px); background: #9c27b0; }
+  .bottom { transform: rotateX(-90deg) translateZ(100px); background: #ff9800; }
+  .instructions {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background: rgba(255,255,255,0.2);
+    padding: 6px 10px;
+    border-radius: 4px;
+    font-size: 14px;
+  }
+</style>
+</head>
+<body>
+<div class="instructions">
+  Drag to rotate. Hold Shift and drag to pull.
+</div>
+<div class="scene">
+  <div class="cube" id="cube">
+    <div class="face front">Front</div>
+    <div class="face back">Back</div>
+    <div class="face right">Right</div>
+    <div class="face left">Left</div>
+    <div class="face top">Top</div>
+    <div class="face bottom">Bottom</div>
+  </div>
+</div>
+<script>
+  const cube = document.getElementById('cube');
+  let startX, startY;
+  let rotateX = -20;
+  let rotateY = -20;
+  let translateZ = 0;
+  let isDragging = false;
+  let action = 'rotate';
+
+  function updateTransform() {
+    cube.style.transform =
+      `rotateX(${rotateX}deg) rotateY(${rotateY}deg) translateZ(${translateZ}px)`;
+  }
+  updateTransform();
+
+  cube.addEventListener('pointerdown', (e) => {
+    isDragging = true;
+    startX = e.clientX;
+    startY = e.clientY;
+    action = (e.shiftKey || e.button === 2) ? 'pull' : 'rotate';
+    cube.style.transition = 'none';
+    cube.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  });
+
+  cube.addEventListener('contextmenu', (e) => e.preventDefault());
+
+  window.addEventListener('pointermove', (e) => {
+    if (!isDragging) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    startX = e.clientX;
+    startY = e.clientY;
+    if (action === 'rotate') {
+      rotateY += dx * 0.5;
+      rotateX -= dy * 0.5;
+    } else {
+      translateZ += dy;
+    }
+    updateTransform();
+  });
+
+  window.addEventListener('pointerup', (e) => {
+    if (!isDragging) return;
+    isDragging = false;
+    cube.style.transition = 'transform 0.6s cubic-bezier(0.17,0.67,0.35,1.3)';
+    if (action === 'pull') {
+      translateZ = 0;
+    }
+    cube.releasePointerCapture(e.pointerId);
+    updateTransform();
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `interactive_cube.html` demonstrating a rotatable cube that can be pulled along the z-axis and springs back when released

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684063a64b148322b363d4f43ca1357f